### PR TITLE
Remove deprecated has_rdoc= from gemspec

### DIFF
--- a/elk.gemspec
+++ b/elk.gemspec
@@ -17,7 +17,6 @@ spec = Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.MD", "MIT-LICENSE"]
 
   s.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
Got this warning:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
> Gem::Specification#has_rdoc= called from /home/henrik/auctionet/tmp/devbox/gems/bundler/gems/elk-5e762f7b2ad2/elk.gemspec:20.